### PR TITLE
Fix schema pruning by tracking inline refs

### DIFF
--- a/test/openapi-normalization.test.ts
+++ b/test/openapi-normalization.test.ts
@@ -89,6 +89,11 @@ describe('OpenAPI normalization', () => {
       const allRefs = new Set();
       collectRefs(trimmedSpec, allRefs);
 
+      const trimmedSchemas = trimmedSpec.components?.schemas || {};
+      expect(Object.keys(trimmedSchemas)).toEqual(
+        expect.arrayContaining(['TestResponse', 'TestResponseSharedThing', 'GetTestTestResponseNested'])
+      );
+
       const propertyRefs = [...allRefs].filter(
         (ref) => typeof ref === 'string' && ref.startsWith('#/properties/')
       );
@@ -102,6 +107,14 @@ describe('OpenAPI normalization', () => {
         return remainder.includes('/');
       });
       expect(nestedComponentRefs).toHaveLength(0);
+
+      const schemaRefs = [...allRefs].filter(
+        (ref) => typeof ref === 'string' && ref.startsWith('#/components/schemas/')
+      );
+      schemaRefs.forEach((ref) => {
+        const schemaName = ref.replace('#/components/schemas/', '');
+        expect(trimmedSchemas[schemaName]).toBeDefined();
+      });
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- ensure findUsedSchemas traverses inline request bodies, responses, and parameters so referenced component schemas stay marked as used
- prevent hoisted component schemas from being pruned by expanding inline usage tracking before deletion
- tighten the OpenAPI normalization test to assert hoisted schemas remain and that all $ref pointers resolve

## Testing
- npm test -- openapi-normalization.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68cd8c428dac83278f7dcdade2e394bc